### PR TITLE
Fix: Definição de política de restart do container.

### DIFF
--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -8,6 +8,7 @@
     name: "{{ service_container_name }}"
     image: "{{ service_container_image }}"
     container_default_behavior: "compatibility"
+    restart_policy: unless-stopped
     purge_networks: "yes"
     networks_cli_compatible: "no"
     state: started


### PR DESCRIPTION
# Fix: Definição de política de restart do container.

Foi identificado através de issue que o serviço do tika ao lidar
com arquivos grandes acabava por travar o container e o container
não voltava.

Com isso então foi aplicada uma política de restart com o
parâmentro de "unless-stopped" para garantir operabilidade
contínua.

- [X] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [X] Dê um titulo que expresse o objetivo do PR
- [X] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [X] Descreva o objetivo do PR
- [X] Inclua links relevantes para a sua modificação/sugestão/correção
- [X] Descreva um passo-a-passo para testar o seu PR

## Issue

Ref: https://github.com/DadosAbertosDeFeira/iac-docker-tika/issues/18

resolve #18

## Objetivo

Resolver problema de restart do Docker.

## Referências

https://docs.ansible.com/ansible/2.5/modules/docker_container_module.html
https://docs.docker.com/config/containers/start-containers-automatically/

## Como testar

Para executar o terratest siga os passos elencados abaixo:

```bash
$ python3 -m venv .venv
$ source .venv/bin/activate
$ pip install -r requirements.txt
```

 - Testando a role:

```bash
$ molecule test
```


<!--
Marque um `x` dentro de [ ] para os itens que você forneceu informação
Para modificar este template no seu repositório, basta criar o arquivo .github/pull_request_template.md nele.
-->